### PR TITLE
Implement unquoting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,5 +11,5 @@ lazy val xmlquote = (project in file(".")).
     commonSettings,
     libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
     libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "1.0.6",
-    libraryDependencies += "org.scalatest" % "scalatest_2.11" % "3.0.1" % "test"
+    libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.13

--- a/src/main/scala/scala/xml/quote/internal/Liftables.scala
+++ b/src/main/scala/scala/xml/quote/internal/Liftables.scala
@@ -13,6 +13,8 @@ trait Liftables extends Nodes {
 
   val args: List[Tree]
 
+  lazy val argsIterator: Iterator[Tree] = args.iterator
+
   def NullableLiftable[T](f: T => Tree): Liftable[T] = Liftable { v =>
     if (v == null) q"null"
     else f(v)
@@ -111,7 +113,7 @@ trait Liftables extends Nodes {
     case pcdata:   xml.PCData   => liftPCData(pcdata)
     case text:     xml.Text     => liftText(text)
     case unparsed: xml.Unparsed => liftUnparsed(unparsed)
-    case hole:     Hole         => args(hole.data)
+    case hole:     Hole         => argsIterator.next
     case atom:     xml.Atom[_]  =>
       atom.data match {
         case c: Char   => q"new $sx.Atom($c)"

--- a/src/main/scala/scala/xml/quote/internal/Liftables.scala
+++ b/src/main/scala/scala/xml/quote/internal/Liftables.scala
@@ -1,7 +1,6 @@
 package scala.xml.quote.internal
 
 import scala.reflect.macros.whitebox.Context
-import scala.xml.quote.internal.QuoteImpl.Hole
 
 trait Liftables extends Nodes {
   val c: Context
@@ -113,7 +112,6 @@ trait Liftables extends Nodes {
     case pcdata:   xml.PCData   => liftPCData(pcdata)
     case text:     xml.Text     => liftText(text)
     case unparsed: xml.Unparsed => liftUnparsed(unparsed)
-    case hole:     Hole         => argsIterator.next
     case atom:     xml.Atom[_]  =>
       atom.data match {
         case c: Char   => q"new $sx.Atom($c)"
@@ -128,6 +126,7 @@ trait Liftables extends Nodes {
     case procinstr: xml.ProcInstr => liftProcInstr(procinstr)
     case entityref: xml.EntityRef => liftEntityRef(entityref)
     case unquote:   Unquote       => liftUnquote(unquote)
+    case Placeholder              => argsIterator.next
   }
 
   implicit def liftGroup: Liftable[xml.Group] = Liftable {

--- a/src/main/scala/scala/xml/quote/internal/Liftables.scala
+++ b/src/main/scala/scala/xml/quote/internal/Liftables.scala
@@ -1,6 +1,7 @@
 package scala.xml.quote.internal
 
 import scala.reflect.macros.whitebox.Context
+import scala.xml.quote.internal.QuoteImpl.Hole
 
 trait Liftables extends Nodes {
   val c: Context
@@ -9,6 +10,8 @@ trait Liftables extends Nodes {
 
   val sx = q"_root_.scala.xml"
   val sci = q"_root_.scala.collection.immutable"
+
+  val args: List[Tree]
 
   def NullableLiftable[T](f: T => Tree): Liftable[T] = Liftable { v =>
     if (v == null) q"null"
@@ -108,6 +111,7 @@ trait Liftables extends Nodes {
     case pcdata:   xml.PCData   => liftPCData(pcdata)
     case text:     xml.Text     => liftText(text)
     case unparsed: xml.Unparsed => liftUnparsed(unparsed)
+    case hole:     Hole         => args(hole.data)
     case atom:     xml.Atom[_]  =>
       atom.data match {
         case c: Char   => q"new $sx.Atom($c)"

--- a/src/main/scala/scala/xml/quote/internal/Parser.scala
+++ b/src/main/scala/scala/xml/quote/internal/Parser.scala
@@ -97,7 +97,6 @@ final class QuoteParser(val inputs: Seq[io.Source], val placeholders: Seq[Hole],
 
       ch match {
         case _ if needPlaceholder =>
-          println("PUT PS")
           ts &+ placeholderIt.next()
           needPlaceholder = false
 

--- a/src/main/scala/scala/xml/quote/internal/Placeholder.scala
+++ b/src/main/scala/scala/xml/quote/internal/Placeholder.scala
@@ -1,0 +1,8 @@
+package scala.xml.quote.internal
+
+import scala.xml.SpecialNode
+
+object Placeholder extends SpecialNode {
+  override def buildString(sb: StringBuilder): StringBuilder = sb
+  override def label: String = "HOLE"
+}

--- a/src/main/scala/scala/xml/quote/internal/QuoteImpl.scala
+++ b/src/main/scala/scala/xml/quote/internal/QuoteImpl.scala
@@ -1,19 +1,17 @@
 package scala.xml.quote.internal
 
-import scala.Predef.{any2stringadd => _, _}
 import scala.language.experimental.macros
 import scala.reflect.macros.whitebox.Context
+import scala.xml.Atom
+import scala.xml.quote.internal.QuoteImpl.Hole
 
 class QuoteImpl(val c: Context) extends Nodes with Liftables with Unliftables {
   import c.universe._
 
   lazy val q"$_($_(..${parts: List[String]})).xml.apply[..$_](..$args)" = c.macroApplication
-  assert(args.length == 0)
 
-  def text(): String = parts.head
-
-  def parse(s: String): xml.Node =
-    new QuoteParser(io.Source.fromString(s), true).initialize.content(xml.TopScope).head
+  def parse(ss: Seq[String]): xml.Node =
+    new QuoteParser(ss map io.Source.fromString, args.zipWithIndex.map(x => new Hole(x._2)), true).initialize.content(xml.TopScope).head
 
   def wrap(node: xml.Node) = q"$node"
 
@@ -22,5 +20,9 @@ class QuoteImpl(val c: Context) extends Nodes with Liftables with Unliftables {
     t
   }
 
-  def apply[T](args: Tree*): Tree = pp(wrap(parse(text())))
+  def apply[T](args: Tree*): Tree = pp(wrap(parse(parts)))
+}
+
+object QuoteImpl {
+  class Hole(data: Int) extends Atom[Int](data)
 }

--- a/src/main/scala/scala/xml/quote/internal/QuoteImpl.scala
+++ b/src/main/scala/scala/xml/quote/internal/QuoteImpl.scala
@@ -2,8 +2,7 @@ package scala.xml.quote.internal
 
 import scala.language.experimental.macros
 import scala.reflect.macros.whitebox.Context
-import scala.xml.Atom
-import scala.xml.quote.internal.QuoteImpl.Hole
+import scala.xml.SpecialNode
 
 class QuoteImpl(val c: Context) extends Nodes with Liftables with Unliftables {
   import c.universe._
@@ -11,18 +10,9 @@ class QuoteImpl(val c: Context) extends Nodes with Liftables with Unliftables {
   lazy val q"$_($_(..${parts: List[String]})).xml.apply[..$_](..$args)" = c.macroApplication
 
   def parse(ss: Seq[String]): xml.Node =
-    new QuoteParser(ss map io.Source.fromString, args.zipWithIndex.map(x => new Hole(x._2)), true).initialize.content(xml.TopScope).head
+    new QuoteParser(ss map io.Source.fromString, true).initialize.content(xml.TopScope).head
 
   def wrap(node: xml.Node) = q"$node"
 
-  def pp[T <: Tree](t: T): T = {
-    println(showCode(t))
-    t
-  }
-
-  def apply[T](args: Tree*): Tree = pp(wrap(parse(parts)))
-}
-
-object QuoteImpl {
-  class Hole(data: Int) extends Atom[Int](data)
+  def apply[T](args: Tree*): Tree = wrap(parse(parts))
 }

--- a/src/test/scala/scala/xml/quote/ConstructionSuite.scala
+++ b/src/test/scala/scala/xml/quote/ConstructionSuite.scala
@@ -71,11 +71,11 @@ class ConstructionSuite extends FunSuite {
      assert(xml"<foo>${2 + 3}</foo>" == <foo>{2 + 3}</foo>)
    }
 
-  // test("reconstruct unquote within unprefixed attribute") {
-  //   assert(xml"<foo a=${"foo" + "bar"}/>" == <foo a={"foo" + "bar"}/>)
-  // }
+   test("reconstruct unquote within unprefixed attribute") {
+     assert(xml"<foo a=${"foo" + "bar"}/>" == <foo a={"foo" + "bar"}/>)
+   }
 
-  // test("reconstruct unquote within prefixed attribute") {
-  //   assert(xml"<foo a:b=${"foo" + "bar"}/>" == <foo a:b={"foo" + "bar"}/>)
-  // }
+   test("reconstruct unquote within prefixed attribute") {
+     assert(xml"<foo a:b=${"foo" + "bar"}/>" == <foo a:b={"foo" + "bar"}/>)
+   }
 }

--- a/src/test/scala/scala/xml/quote/ConstructionSuite.scala
+++ b/src/test/scala/scala/xml/quote/ConstructionSuite.scala
@@ -1,5 +1,6 @@
+package scala.xml.quote
+
 import org.scalatest.FunSuite
-import scala.xml.quote._
 
 class ConstructionSuite extends FunSuite {
   test("reconstruct comment") {
@@ -66,9 +67,9 @@ class ConstructionSuite extends FunSuite {
     assert(xml"""<foo xmlns:pre="a"><bar xmlns:pre="b"/></foo>""" == <foo xmlns:pre="a"><bar xmlns:pre="b"/></foo>)
   }
 
-  // test("reconstruct unquote within elem") {
-  //   assert(xml"<foo>${2 + 3}</foo>" == <foo>{2 + 3}</foo>)
-  // }
+//   test("reconstruct unquote within elem") {
+//     assert(xml"<foo>${2 + 3}</foo>" == <foo>{2 + 3}</foo>)
+//   }
 
   // test("reconstruct unquote within unprefixed attribute") {
   //   assert(xml"<foo a=${"foo" + "bar"}/>" == <foo a={"foo" + "bar"}/>)

--- a/src/test/scala/scala/xml/quote/ConstructionSuite.scala
+++ b/src/test/scala/scala/xml/quote/ConstructionSuite.scala
@@ -67,9 +67,9 @@ class ConstructionSuite extends FunSuite {
     assert(xml"""<foo xmlns:pre="a"><bar xmlns:pre="b"/></foo>""" == <foo xmlns:pre="a"><bar xmlns:pre="b"/></foo>)
   }
 
-//   test("reconstruct unquote within elem") {
-//     assert(xml"<foo>${2 + 3}</foo>" == <foo>{2 + 3}</foo>)
-//   }
+   test("reconstruct unquote within elem") {
+     assert(xml"<foo>${2 + 3}</foo>" == <foo>{2 + 3}</foo>)
+   }
 
   // test("reconstruct unquote within unprefixed attribute") {
   //   assert(xml"<foo a=${"foo" + "bar"}/>" == <foo a={"foo" + "bar"}/>)


### PR DESCRIPTION
Hi,

  I've tried to implement unquoting. This code is definitely not production ready, but just to show my vision on how it might be implemented. My approach is quite different than it is done in #12. I tried to avoid hacking strings. It is easy for content, but I'm still thinking how to deal with attributes, because both `Metadata` and `NamespaceBinding` expect string values at the construction time. I think, I can inherit these classes to show that here is a hole and it will be substituted later (of course it requires quite a lot of coding because of how scala-xml parsers implemented) . Another approach is to put strings into the `Hole`, but I'm not sure how to decompose AST properly to cover all cases (literals, variables, calls, etc), if it possible.

Please, add your comments and suggestions.