### PR TITLE
Use `()` for the unit value

### DIFF
--- a/src/main/scala/scala/xml/quote/internal/XmlParser.scala
+++ b/src/main/scala/scala/xml/quote/internal/XmlParser.scala
@@ -123,6 +123,6 @@ private[internal] object XmlParser {
 
   private implicit class ParserOps[T](val self: P[T]) extends AnyVal {
     /** Discard the result of this parser */
-    def toP0: P0 = self.map(_ => Unit)
+    def toP0: P0 = self.map(_ => ())
   }
 }


### PR DESCRIPTION
In scala 2.13.0 using 'Unit' will result in an error, see https://github.com/scala/scala/pull/7698